### PR TITLE
[TECH] Spécifier que notre package npm doit être publié publiquement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/1024pix/oppsy.git"
   },
+  "publishConfig": { "access": "public" },
   "description": "An EventEmitter useful for collecting hapi server ops information",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
## :unicorn: Problème
Par défaut npm publie les packages en privé. Il faut lui préciser qu'on souhaite créer un package public.

C'est par exemple possible avec la CLI :

```shell
$ npm publish --access public
```

## :robot: Proposition
Ajouter une configuration dans le package.json pour le spécifier.

## :rainbow: Remarques
RAS

## :100: Pour tester
No idea.
