### PR TITLE
[TECH] Mise en place du trusted publishing de npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,21 @@
 name: release
 
+permissions:
+  id-token: write
+
 on:
   push:
     branches:
       - main
   repository_dispatch:
-    types: ['deploy']
+    types: ["deploy"]
   workflow_dispatch:
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -21,5 +24,4 @@ jobs:
           npmPublish: true
           updateMajorVersion: true
         env:
-          GITHUB_TOKEN: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_ACCESS_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"


### PR DESCRIPTION
## :christmas_tree: Problème

La publication de package npm avec token est déconseillée.
De plus les tokens ont maintenant une durée de vie maximum de 90 jours.

## :gift: Proposition

Passer au système de [Trusted publishing](https://docs.npmjs.com/trusted-publishers) proposé par npm.

## :star2: Remarques

N/A

## :santa: Pour tester

Ça a été testé avec succès sur le package `@1024pix/pix-ui`